### PR TITLE
fix(hosted-url): activation of package on self-hosted url #45

### DIFF
--- a/lib/src/pub_updater.dart
+++ b/lib/src/pub_updater.dart
@@ -13,7 +13,10 @@ class PackageInfoRequestFailure implements Exception {}
 class PackageInfoNotFoundFailure implements Exception {}
 
 /// The pub.dev base url for querying package versions
-const _defaultBaseUrl = 'https://pub.dev/api/packages/';
+const _defaultBaseUrl = 'https://pub.dev';
+
+/// The pub.dev api query path for querying packages
+const _pubPackagesPath = '/api/packages/';
 
 /// {@template pub_update}
 /// A Dart package which enables checking whether a package is up to date.
@@ -69,12 +72,13 @@ class PubUpdater {
         'activate',
         packageName,
         if (versionConstraint != null) versionConstraint,
+        if (_baseUrl != _defaultBaseUrl) ...['-u', _baseUrl]
       ],
     );
   }
 
   Future<PackageInfo> _getPackageInfo(String packageName) async {
-    final uri = Uri.parse('$_baseUrl$packageName');
+    final uri = Uri.parse('$_baseUrl$_pubPackagesPath$packageName');
     final response = await _get(uri);
 
     if (response.statusCode != HttpStatus.ok) throw PackageInfoRequestFailure();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: pub_updater
 description: A Dart package which enables checking whether a package is up to date.
-version: 0.3.0
+version: 0.3.1
 homepage: https://github.com/VeryGoodOpenSource/pub_updater
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.12.0 <4.0.0"
 
 dependencies:
   http: ^0.13.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pub_updater
 description: A Dart package which enables checking whether a package is up to date.
-version: 0.3.1
+version: 0.3.0
 homepage: https://github.com/VeryGoodOpenSource/pub_updater
 
 environment:

--- a/test/pub_update_test.dart
+++ b/test/pub_update_test.dart
@@ -26,6 +26,15 @@ const command = [
   'activate',
   'very_good_cli',
 ];
+const commandWithCustomBaseUrl = [
+  'dart',
+  'pub',
+  'global',
+  'activate',
+  'very_good_cli',
+  '-u',
+  customBaseUrl,
+];
 const commandWithConstraint = [
   'dart',
   'pub',
@@ -34,8 +43,18 @@ const commandWithConstraint = [
   'very_good_cli',
   '>=0.4.0',
 ];
+const commandWithConstraintAndCustomBaseUrl = [
+  'dart',
+  'pub',
+  'global',
+  'activate',
+  'very_good_cli',
+  '>=0.4.0',
+  '-u',
+  customBaseUrl,
+];
 
-const customBaseUrl = 'https://custom-domain.com/api/packages/';
+const customBaseUrl = 'https://custom-domain.com';
 
 void main() {
   group('PubUpdater', () {
@@ -104,7 +123,7 @@ void main() {
 
         verify(
           () => client.get(
-            Uri.parse('${customBaseUrl}very_good_cli'),
+            Uri.parse('$customBaseUrl/api/packages/very_good_cli'),
           ),
         ).called(1);
       });
@@ -231,7 +250,7 @@ void main() {
 
         verify(
           () => client.get(
-            Uri.parse('${customBaseUrl}very_good_cli'),
+            Uri.parse('$customBaseUrl/api/packages/very_good_cli'),
           ),
         ).called(1);
       });
@@ -270,6 +289,14 @@ void main() {
         );
         verify(() => processManager.run(command)).called(1);
       });
+      test('makes correct call to process.run with customBaseUrl', () async {
+        pubUpdater = PubUpdater(client, customBaseUrl);
+        await pubUpdater.update(
+          packageName: 'very_good_cli',
+          processManager: processManager,
+        );
+        verify(() => processManager.run(commandWithCustomBaseUrl)).called(1);
+      });
 
       test('makes correct call to process.run with version constraint',
           () async {
@@ -279,6 +306,18 @@ void main() {
           versionConstraint: '>=0.4.0',
         );
         verify(() => processManager.run(commandWithConstraint)).called(1);
+      });
+
+      test('makes correct call to process.run with version constraint',
+          () async {
+        pubUpdater = PubUpdater(client, customBaseUrl);
+        await pubUpdater.update(
+          packageName: 'very_good_cli',
+          processManager: processManager,
+          versionConstraint: '>=0.4.0',
+        );
+        verify(() => processManager.run(commandWithConstraintAndCustomBaseUrl))
+            .called(1);
       });
     });
   });


### PR DESCRIPTION


<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This pull request fixes working with customBaseUrl and package activation.
If the base url is not https://pub.dev/ it adds a parameter -u hosted-url parameter to the activation command.

add support for flutter 3.10 by increasing environment sdk range <4.0.0

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
